### PR TITLE
upgrade handling of node key constraints to v5

### DIFF
--- a/SchematicNeo4j/SchematicNeo4j.Attributes/NodeAttribute.cs
+++ b/SchematicNeo4j/SchematicNeo4j.Attributes/NodeAttribute.cs
@@ -9,6 +9,7 @@ namespace SchematicNeo4j.Attributes
     /// </summary>
     /// <remarks>
     /// The class name will be used for the Label unless a Label property is set.
+    /// The node key will be `nk`+class name or the first label in the Label property.
     /// </remarks>
     /// <example>
     /// [Node(Label="Vehicle:Car")] | [Node(Label="Person")] | [Node]
@@ -17,5 +18,9 @@ namespace SchematicNeo4j.Attributes
     public class NodeAttribute : Attribute
     {
         public string Label;
+        /// <summary>
+        /// The Name of the NodeKey Constraint if any, defaults to `nk`+firstLabel.
+        /// </summary>
+        public string NodeKey;
     }
 }

--- a/SchematicNeo4j/SchematicNeo4j.Attributes/NodeAttribute.cs
+++ b/SchematicNeo4j/SchematicNeo4j.Attributes/NodeAttribute.cs
@@ -17,10 +17,25 @@ namespace SchematicNeo4j.Attributes
     [System.AttributeUsage(AttributeTargets.Class, Inherited = true, AllowMultiple = false)]
     public class NodeAttribute : Attribute
     {
+        /// <summary>
+        /// The LabelName of the node. Supports multilabel
+        /// </summary>
+        /// <remarks>
+        /// Defaults to the class name
+        /// </remarks>
+        /// <example>
+        /// Label="Vehicle:Car" or Label="Person"
+        /// </example>
         public string Label;
+
         /// <summary>
         /// The Name of the NodeKey Constraint if any, defaults to `nk`+firstLabel.
         /// </summary>
         public string NodeKey;
+
+        public override string ToString()
+        {
+            return Label;
+        }
     }
 }

--- a/SchematicNeo4j/SchematicNeo4j.Attributes/RelationshipAttribute.cs
+++ b/SchematicNeo4j/SchematicNeo4j.Attributes/RelationshipAttribute.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace SchematicNeo4j.Attributes
+{
+    /// <summary>
+    /// Indicates a Class is a Graph Relationship.
+    /// </summary>
+    /// <remarks>
+    /// The class name, properly formatted for convention, will be used for the Relationship TYPE_NAME unless a TypeName is set.
+    /// </remarks>
+    /// <example>
+    /// `[Relationship(TypeName="ACTED_IN")]` | `[Relationship] public class ActedIn`
+    /// </example>
+    [System.AttributeUsage(AttributeTargets.Class, Inherited = true, AllowMultiple = false)]
+    public class RelationshipAttribute : Attribute
+    {
+        public string TypeName;
+
+        public override string ToString()
+        {
+            return TypeName;
+        }
+    }
+}

--- a/SchematicNeo4j/SchematicNeo4j.Tests/Extensions/CreateIndexes_Tests.cs
+++ b/SchematicNeo4j/SchematicNeo4j.Tests/Extensions/CreateIndexes_Tests.cs
@@ -101,7 +101,7 @@ namespace SchematicNeo4j.Tests.Extensions
             // Execute
             using (ISession session = driver.Session(o => o.WithDefaultAccessMode(AccessMode.Write)))
             {
-                session.WriteTransaction(tx => { testType.CreateIndexes(tx); return true; });
+                session.ExecuteWrite(tx => { testType.CreateIndexes(tx); return true; });
             }
 
             // Test Outcome
@@ -117,7 +117,7 @@ namespace SchematicNeo4j.Tests.Extensions
         {
             using (var session = driver.Session(o => o.WithDefaultAccessMode(AccessMode.Write)))
             {
-                session.WriteTransaction(tx => {
+                session.ExecuteWrite(tx => {
                     foreach (Index item in expected)
                     {
                         if (item.Exists(tx))
@@ -132,7 +132,7 @@ namespace SchematicNeo4j.Tests.Extensions
         {
             using (ISession session = driver.Session(o => o.WithDefaultAccessMode(AccessMode.Read)))
             {
-                var recordList = session.ReadTransaction(tx => tx.Run("CALL db.indexes() yield indexName, tokenNames, properties WITH CASE indexName WHEN 'Unnamed index' THEN null ELSE indexName END as Name, tokenNames[0] as Label, properties as Properties WHERE Label = $Label AND Properties = $Properties RETURN *", index).ToList());
+                var recordList = session.ExecuteRead(tx => tx.Run("CALL db.indexes() yield indexName, tokenNames, properties WITH CASE indexName WHEN 'Unnamed index' THEN null ELSE indexName END as Name, tokenNames[0] as Label, properties as Properties WHERE Label = $Label AND Properties = $Properties RETURN *", index).ToList());
                 return recordList.Select(record => new Index(name: record["Name"].As<string>(), label: record["Label"].As<string>(), properties: record["Properties"].As<IList<string>>().ToArray<string>())).FirstOrDefault();
             }
         }

--- a/SchematicNeo4j/SchematicNeo4j.Tests/Extensions/DropIndexes_Tests.cs
+++ b/SchematicNeo4j/SchematicNeo4j.Tests/Extensions/DropIndexes_Tests.cs
@@ -92,7 +92,7 @@ namespace SchematicNeo4j.Tests.Extensions
             // Execute
             using (ISession session = driver.Session(o => o.WithDefaultAccessMode(AccessMode.Write)))
             {
-                session.WriteTransaction(tx => { testType.DropIndexes(tx); return true; });
+                session.ExecuteWrite(tx => { testType.DropIndexes(tx); return true; });
             }
 
             // Test Outcome
@@ -103,7 +103,7 @@ namespace SchematicNeo4j.Tests.Extensions
         {
             using (var session = driver.Session(o => o.WithDefaultAccessMode(AccessMode.Write)))
             {
-                session.WriteTransaction(tx => {
+                session.ExecuteWrite(tx => {
                     foreach (Index item in notExpected)
                     {
                         if (item.Exists(tx))
@@ -118,7 +118,7 @@ namespace SchematicNeo4j.Tests.Extensions
         {
             using (ISession session = driver.Session(o => o.WithDefaultAccessMode(AccessMode.Read)))
             {
-                var recordList = session.ReadTransaction(tx => tx.Run("CALL db.indexes() yield indexName, tokenNames, properties WITH CASE indexName WHEN 'Unnamed index' THEN null ELSE indexName END as Name, tokenNames[0] as Label, properties as Properties WHERE Label = $Label AND Properties = $Properties RETURN *", index).ToList());
+                var recordList = session.ExecuteRead(tx => tx.Run("CALL db.indexes() yield indexName, tokenNames, properties WITH CASE indexName WHEN 'Unnamed index' THEN null ELSE indexName END as Name, tokenNames[0] as Label, properties as Properties WHERE Label = $Label AND Properties = $Properties RETURN *", index).ToList());
                 return recordList.Select(record => new Index(name: record["Name"].As<string>(), label: record["Label"].As<string>(), properties: record["Properties"].As<IList<string>>().ToArray<string>())).FirstOrDefault();
             }
         }

--- a/SchematicNeo4j/SchematicNeo4j.Tests/Indexes/Index_Create_Tests.cs
+++ b/SchematicNeo4j/SchematicNeo4j.Tests/Indexes/Index_Create_Tests.cs
@@ -110,7 +110,7 @@ namespace SchematicNeo4j.Tests.Indexes
         {
             using (var session = driver.Session(o => o.WithDefaultAccessMode(AccessMode.Write)))
             {
-                session.WriteTransaction(tx => {
+                session.ExecuteWrite(tx => {
                     if (testIndex.Exists(tx))
                         tx.Run("DROP INDEX ON :IndexCreateTest(Prop1,Prop2)");
                     return true;
@@ -123,7 +123,7 @@ namespace SchematicNeo4j.Tests.Indexes
         {
             using (ISession session = driver.Session(o => o.WithDefaultAccessMode(AccessMode.Write)))
             {
-                session.WriteTransaction(tx => { tx.Run("CREATE INDEX ON :IndexCreateTest(Prop1,Prop2)"); return true; });
+                session.ExecuteWrite(tx => { tx.Run("CREATE INDEX ON :IndexCreateTest(Prop1,Prop2)"); return true; });
             }
         }
 
@@ -131,7 +131,7 @@ namespace SchematicNeo4j.Tests.Indexes
         {
             using (ISession session = driver.Session(o => o.WithDefaultAccessMode(AccessMode.Read)))
             {
-                var recordList = session.ReadTransaction(tx => tx.Run("CALL db.indexes() yield indexName, tokenNames, properties WITH CASE indexName WHEN 'Unnamed index' THEN null ELSE indexName END as Name, tokenNames[0] as Label, properties as Properties WHERE Label = $Label AND Properties = $Properties RETURN *", index).ToList());
+                var recordList = session.ExecuteRead(tx => tx.Run("CALL db.indexes() yield indexName, tokenNames, properties WITH CASE indexName WHEN 'Unnamed index' THEN null ELSE indexName END as Name, tokenNames[0] as Label, properties as Properties WHERE Label = $Label AND Properties = $Properties RETURN *", index).ToList());
                 return recordList.Select(record => new Index(name: record["Name"].As<string>(), label: record["Label"].As<string>(), properties: record["Properties"].As<IList<string>>().ToArray<string>())).FirstOrDefault();
             }
         }
@@ -140,7 +140,7 @@ namespace SchematicNeo4j.Tests.Indexes
         {
             using (ISession session = driver.Session(o => o.WithDefaultAccessMode(AccessMode.Read)))
             {
-                var recordList = session.ReadTransaction(tx => tx.Run("CALL db.indexes() yield indexName, tokenNames, properties WITH indexName as Name, tokenNames[0] as Label, properties as Properties WHERE Label = $Label AND Properties = $Properties RETURN *", index).ToList());
+                var recordList = session.ExecuteRead(tx => tx.Run("CALL db.indexes() yield indexName, tokenNames, properties WITH indexName as Name, tokenNames[0] as Label, properties as Properties WHERE Label = $Label AND Properties = $Properties RETURN *", index).ToList());
                 return recordList.Select(record => new Index(name: record["Name"].As<string>(), label: record["Label"].As<string>(), properties: record["Properties"].As<IList<string>>().ToArray<string>())).FirstOrDefault();
             }
         }

--- a/SchematicNeo4j/SchematicNeo4j.Tests/Indexes/Index_Drop_Tests.cs
+++ b/SchematicNeo4j/SchematicNeo4j.Tests/Indexes/Index_Drop_Tests.cs
@@ -106,7 +106,7 @@ namespace SchematicNeo4j.Tests.Indexes
         {
             using (var session = driver.Session(o => o.WithDefaultAccessMode(AccessMode.Write)))
             {
-                session.WriteTransaction(tx => {
+                session.ExecuteWrite(tx => {
                     if (testIndex.Exists(tx))
                         tx.Run("DROP INDEX ON :IndexDropTest(Prop1,Prop2)");
                     return true;
@@ -119,7 +119,7 @@ namespace SchematicNeo4j.Tests.Indexes
         {
             using (ISession session = driver.Session(o => o.WithDefaultAccessMode(AccessMode.Write)))
             {
-                session.WriteTransaction(tx => tx.Run("CREATE INDEX ON :IndexDropTest(Prop1,Prop2)"));
+                session.ExecuteWrite(tx => tx.Run("CREATE INDEX ON :IndexDropTest(Prop1,Prop2)"));
             }
         }
 
@@ -127,7 +127,7 @@ namespace SchematicNeo4j.Tests.Indexes
         {
             using (ISession session = driver.Session(o => o.WithDefaultAccessMode(AccessMode.Read)))
             {
-                var recordList = session.ReadTransaction(tx => tx.Run("CALL db.indexes() yield indexName, tokenNames, properties WITH CASE indexName WHEN 'Unnamed index' THEN null ELSE indexName END as Name, tokenNames[0] as Label, properties as Properties WHERE Label = $Label AND Properties = $Properties RETURN *", index).ToList());
+                var recordList = session.ExecuteRead(tx => tx.Run("CALL db.indexes() yield indexName, tokenNames, properties WITH CASE indexName WHEN 'Unnamed index' THEN null ELSE indexName END as Name, tokenNames[0] as Label, properties as Properties WHERE Label = $Label AND Properties = $Properties RETURN *", index).ToList());
                 return recordList.Select(record => new Index(name: record["Name"].As<string>(), label: record["Label"].As<string>(), properties: record["Properties"].As<IList<string>>().ToArray<string>())).FirstOrDefault();
             }
         }
@@ -136,7 +136,7 @@ namespace SchematicNeo4j.Tests.Indexes
         {
             using (ISession session = driver.Session(o => o.WithDefaultAccessMode(AccessMode.Read)))
             {
-                var recordList = session.ReadTransaction(tx => tx.Run("CALL db.indexes() yield indexName, tokenNames, properties WITH indexName as Name, tokenNames[0] as Label, properties as Properties WHERE Label = $Label AND Properties = $Properties RETURN *", index).ToList());
+                var recordList = session.ExecuteRead(tx => tx.Run("CALL db.indexes() yield indexName, tokenNames, properties WITH indexName as Name, tokenNames[0] as Label, properties as Properties WHERE Label = $Label AND Properties = $Properties RETURN *", index).ToList());
                 return recordList.Select(record => new Index(name: record["Name"].As<string>(), label: record["Label"].As<string>(), properties: record["Properties"].As<IList<string>>().ToArray<string>())).FirstOrDefault();
             }
         }

--- a/SchematicNeo4j/SchematicNeo4j.Tests/Indexes/Index_Exists_Tests.cs
+++ b/SchematicNeo4j/SchematicNeo4j.Tests/Indexes/Index_Exists_Tests.cs
@@ -87,7 +87,7 @@ namespace SchematicNeo4j.Tests.Indexes
         {
             using (var session = driver.Session(o => o.WithDefaultAccessMode(AccessMode.Write)))
             {
-                session.WriteTransaction(tx => {
+                session.ExecuteWrite(tx => {
                     if (testIndex.Exists(tx))
                         tx.Run("DROP INDEX ON :Truck(Make,TowingCapacity)");
                     return true;
@@ -100,7 +100,7 @@ namespace SchematicNeo4j.Tests.Indexes
         {
             using (ISession session = driver.Session(o => o.WithDefaultAccessMode(AccessMode.Write)))
             {
-                session.WriteTransaction(tx => { tx.Run("CREATE INDEX ON :Truck(Make,TowingCapacity)"); return true; });
+                session.ExecuteWrite(tx => { tx.Run("CREATE INDEX ON :Truck(Make,TowingCapacity)"); return true; });
             }
         }
 
@@ -108,7 +108,7 @@ namespace SchematicNeo4j.Tests.Indexes
         {
             using (ISession session = driver.Session(o => o.WithDefaultAccessMode(AccessMode.Read)))
             {
-                var recordList = session.ReadTransaction(tx => tx.Run("CALL db.indexes() yield indexName, tokenNames, properties WITH indexName as Name, tokenNames[0] as Label, properties as Properties WHERE Label = $Label AND Properties = $Properties RETURN *", index).ToList());
+                var recordList = session.ExecuteRead(tx => tx.Run("CALL db.indexes() yield indexName, tokenNames, properties WITH indexName as Name, tokenNames[0] as Label, properties as Properties WHERE Label = $Label AND Properties = $Properties RETURN *", index).ToList());
                 return recordList.Select(record => new Index(label: record["Label"].As<string>(), properties: record["Properties"].As<IList<string>>().ToArray<string>())).FirstOrDefault();
             }
         }

--- a/SchematicNeo4j/SchematicNeo4j.Tests/NodeKey/NodeKey_Create_Tests.cs
+++ b/SchematicNeo4j/SchematicNeo4j.Tests/NodeKey/NodeKey_Create_Tests.cs
@@ -9,11 +9,13 @@ using SchematicNeo4j;
 
 namespace SchematicNeo4j.Tests.NodeKey
 {
-    public class NodeKey_Create_Tests :IDisposable
+    public class NodeKey_Create_Tests : IDisposable
     {
         private IDriver driver = null;
-        private string carConstraint = "CONSTRAINT ON ( car:Car ) ASSERT (car.Make, car.Model, car.ModelYear) IS NODE KEY";
-        private string personConstraint = "CONSTRAINT ON ( person:Person ) ASSERT (person.Name) IS NODE KEY";
+        private string carConstraint = "CREATE CONSTRAINT `nkCar` FOR (n:`Car`) REQUIRE (n.`Make`, n.`Model`, n.`ModelYear`) IS NODE KEY OPTIONS {indexConfig: {}, indexProvider: 'range-1.0'}";
+        private ConstraintRecord carConstraintRecord = new() { name = "nkCar" };
+        private string personConstraint = "CREATE CONSTRAINT `nkPerson` FOR (person:`Person`) REQUIRE (person.`Name`) IS NODE KEY OPTIONS {indexConfig: {}, indexProvider: 'range-1.0'}";
+        private ConstraintRecord personConstraintRecord = new() { name = "nkPerson" };
 
         public NodeKey_Create_Tests()
         {
@@ -57,7 +59,7 @@ namespace SchematicNeo4j.Tests.NodeKey
         [Fact]
         public void NodeKey_Create_Will_ThrowException_For_Type_With_No_Driver()
         {
-            
+
             // Set Driver for SchematicNeo4j to null
             SchematicNeo4j.GraphConnection.SetDriver(null);
             // Execute
@@ -86,9 +88,9 @@ namespace SchematicNeo4j.Tests.NodeKey
             using (var session = driver.Session(o => o.WithDefaultAccessMode(AccessMode.Write)))
             {
                 if (GetConstraints("NODE KEY", "Car").Count() == 1)
-                    session.ExecuteWrite(tx => tx.Run($"DROP {carConstraint}"));
+                    session.ExecuteWrite(tx => tx.Run($"DROP CONSTRAINT {carConstraintRecord.name}"));
                 if (GetConstraints("NODE KEY", "Person").Count() == 1)
-                    session.ExecuteWrite(tx => tx.Run($"DROP {personConstraint}"));
+                    session.ExecuteWrite(tx => tx.Run($"DROP CONSTRAINT {personConstraintRecord.name}"));
             }
         }
 
@@ -96,10 +98,12 @@ namespace SchematicNeo4j.Tests.NodeKey
         {
             using (var session = driver.Session(o => o.WithDefaultAccessMode(AccessMode.Write)))
             {
-                return session.ExecuteRead(tx => tx.Run(
-                    "CALL db.constraints() yield description WHERE description contains (':'+$typeLabel+' ') AND description contains $constraintType RETURN description",
+                return session.ExecuteRead(tx =>
+                tx.Run(
+                    "SHOW CONSTRAINTS YIELD createStatement WHERE createStatement contains (':`'+$typeLabel+'`') AND createStatement contains $constraintType RETURN createStatement",
                     new { typeLabel = forLabel, constraintType = ofType }
-                    ).ToList());
+                    ).ToList()
+                );
             }
         }
 

--- a/SchematicNeo4j/SchematicNeo4j.Tests/NodeKey/NodeKey_Create_Tests.cs
+++ b/SchematicNeo4j/SchematicNeo4j.Tests/NodeKey/NodeKey_Create_Tests.cs
@@ -86,9 +86,9 @@ namespace SchematicNeo4j.Tests.NodeKey
             using (var session = driver.Session(o => o.WithDefaultAccessMode(AccessMode.Write)))
             {
                 if (GetConstraints("NODE KEY", "Car").Count() == 1)
-                    session.WriteTransaction(tx => tx.Run($"DROP {carConstraint}"));
+                    session.ExecuteWrite(tx => tx.Run($"DROP {carConstraint}"));
                 if (GetConstraints("NODE KEY", "Person").Count() == 1)
-                    session.WriteTransaction(tx => tx.Run($"DROP {personConstraint}"));
+                    session.ExecuteWrite(tx => tx.Run($"DROP {personConstraint}"));
             }
         }
 
@@ -96,7 +96,7 @@ namespace SchematicNeo4j.Tests.NodeKey
         {
             using (var session = driver.Session(o => o.WithDefaultAccessMode(AccessMode.Write)))
             {
-                return session.ReadTransaction(tx => tx.Run(
+                return session.ExecuteRead(tx => tx.Run(
                     "CALL db.constraints() yield description WHERE description contains (':'+$typeLabel+' ') AND description contains $constraintType RETURN description",
                     new { typeLabel = forLabel, constraintType = ofType }
                     ).ToList());

--- a/SchematicNeo4j/SchematicNeo4j.Tests/NodeKey/NodeKey_Drop_Tests.cs
+++ b/SchematicNeo4j/SchematicNeo4j.Tests/NodeKey/NodeKey_Drop_Tests.cs
@@ -29,7 +29,7 @@ namespace SchematicNeo4j.Tests.NodeKey
             // Setup
             using (var session = driver.Session(o => o.WithDefaultAccessMode(AccessMode.Write)))
             {
-                session.WriteTransaction(tx => tx.Run($"CREATE {personConstraint}"));
+                session.ExecuteWrite(tx => tx.Run($"CREATE {personConstraint}"));
             }
             //Confirm Setup
             Assert.Single(GetConstraints("NODE KEY", "Person"));
@@ -52,7 +52,7 @@ namespace SchematicNeo4j.Tests.NodeKey
             // Setup
             using (var session = driver.Session(o => o.WithDefaultAccessMode(AccessMode.Write)))
             {
-                session.WriteTransaction(tx => tx.Run($"CREATE {personConstraint}"));
+                session.ExecuteWrite(tx => tx.Run($"CREATE {personConstraint}"));
             }
             //Confirm Setup
             Assert.Single(GetConstraints("NODE KEY", "Person"));
@@ -76,7 +76,7 @@ namespace SchematicNeo4j.Tests.NodeKey
             // Setup
             using (var session = driver.Session(o => o.WithDefaultAccessMode(AccessMode.Write)))
             {
-                session.WriteTransaction(tx => tx.Run($"CREATE {personConstraint}"));
+                session.ExecuteWrite(tx => tx.Run($"CREATE {personConstraint}"));
             }
             //Confirm Setup
             Assert.Single(GetConstraints("NODE KEY", "Person"));
@@ -106,7 +106,7 @@ namespace SchematicNeo4j.Tests.NodeKey
             using (var session = driver.Session(o => o.WithDefaultAccessMode(AccessMode.Write)))
             {
                 if (GetConstraints("NODE KEY", "Person").Count() == 1)
-                    session.WriteTransaction(tx => tx.Run($"DROP {personConstraint}"));
+                    session.ExecuteWrite(tx => tx.Run($"DROP {personConstraint}"));
             }
         }
 
@@ -114,7 +114,7 @@ namespace SchematicNeo4j.Tests.NodeKey
         {
             using (var session = driver.Session(o => o.WithDefaultAccessMode(AccessMode.Read)))
             {
-                return session.ReadTransaction(tx => tx.Run(
+                return session.ExecuteRead(tx => tx.Run(
                     "CALL db.constraints() yield description WHERE description contains (':'+$typeLabel+' ') AND description contains $constraintType RETURN description",
                     new { typeLabel = forLabel, constraintType = ofType }
                     ).ToList());

--- a/SchematicNeo4j/SchematicNeo4j.Tests/NodeKey/NodeKey_Drop_Tests.cs
+++ b/SchematicNeo4j/SchematicNeo4j.Tests/NodeKey/NodeKey_Drop_Tests.cs
@@ -56,6 +56,10 @@ namespace SchematicNeo4j.Tests.NodeKey
             {
                 session.ExecuteWrite(tx => tx.Run($"{personConstraint}"));
             }
+
+            // TODO: This is occassionally failing with the Create_Tests using the same constraint and tests running in parallel.
+            // Running the Drop tests separate from create is successful 100% of the time.
+
             //Confirm Setup
             Assert.Single(GetConstraints("NODE KEY", "Person"));
             Assert.Equal(personConstraint, GetConstraints("NODE KEY", "Person").First()[0]);

--- a/SchematicNeo4j/SchematicNeo4j.Tests/NodeKey/NodeKey_Drop_Tests.cs
+++ b/SchematicNeo4j/SchematicNeo4j.Tests/NodeKey/NodeKey_Drop_Tests.cs
@@ -12,8 +12,10 @@ namespace SchematicNeo4j.Tests.NodeKey
     public class NodeKey_Drop_Tests : IDisposable
     {
         private IDriver driver = null;
-        
-        private string personConstraint = "CONSTRAINT ON ( person:Person ) ASSERT (person.Name) IS NODE KEY";
+
+        private string personConstraint = "CREATE CONSTRAINT `nkPerson` FOR (n:`Person`) REQUIRE (n.`Name`) IS NODE KEY OPTIONS {indexConfig: {}, indexProvider: 'range-1.0'}";
+        private ConstraintRecord personConstraintRecord = new() { name = "nkPerson" };
+
 
         public NodeKey_Drop_Tests()
         {
@@ -29,7 +31,7 @@ namespace SchematicNeo4j.Tests.NodeKey
             // Setup
             using (var session = driver.Session(o => o.WithDefaultAccessMode(AccessMode.Write)))
             {
-                session.ExecuteWrite(tx => tx.Run($"CREATE {personConstraint}"));
+                session.ExecuteWrite(tx => tx.Run($"{personConstraint}"));
             }
             //Confirm Setup
             Assert.Single(GetConstraints("NODE KEY", "Person"));
@@ -52,7 +54,7 @@ namespace SchematicNeo4j.Tests.NodeKey
             // Setup
             using (var session = driver.Session(o => o.WithDefaultAccessMode(AccessMode.Write)))
             {
-                session.ExecuteWrite(tx => tx.Run($"CREATE {personConstraint}"));
+                session.ExecuteWrite(tx => tx.Run($"{personConstraint}"));
             }
             //Confirm Setup
             Assert.Single(GetConstraints("NODE KEY", "Person"));
@@ -76,7 +78,7 @@ namespace SchematicNeo4j.Tests.NodeKey
             // Setup
             using (var session = driver.Session(o => o.WithDefaultAccessMode(AccessMode.Write)))
             {
-                session.ExecuteWrite(tx => tx.Run($"CREATE {personConstraint}"));
+                session.ExecuteWrite(tx => tx.Run($"{personConstraint}"));
             }
             //Confirm Setup
             Assert.Single(GetConstraints("NODE KEY", "Person"));
@@ -106,7 +108,7 @@ namespace SchematicNeo4j.Tests.NodeKey
             using (var session = driver.Session(o => o.WithDefaultAccessMode(AccessMode.Write)))
             {
                 if (GetConstraints("NODE KEY", "Person").Count() == 1)
-                    session.ExecuteWrite(tx => tx.Run($"DROP {personConstraint}"));
+                    session.ExecuteWrite(tx => tx.Run($"DROP CONSTRAINT {personConstraintRecord.name}"));
             }
         }
 
@@ -115,12 +117,10 @@ namespace SchematicNeo4j.Tests.NodeKey
             using (var session = driver.Session(o => o.WithDefaultAccessMode(AccessMode.Read)))
             {
                 return session.ExecuteRead(tx => tx.Run(
-                    "CALL db.constraints() yield description WHERE description contains (':'+$typeLabel+' ') AND description contains $constraintType RETURN description",
+                    "SHOW CONSTRAINTS YIELD createStatement WHERE createStatement contains (':`'+$typeLabel+'`') AND createStatement contains $constraintType RETURN createStatement",
                     new { typeLabel = forLabel, constraintType = ofType }
                     ).ToList());
             }
         }
-
-
     }
 }

--- a/SchematicNeo4j/SchematicNeo4j.Tests/NodeKey/NodeKey_Exists_Tests.cs
+++ b/SchematicNeo4j/SchematicNeo4j.Tests/NodeKey/NodeKey_Exists_Tests.cs
@@ -33,7 +33,7 @@ namespace SchematicNeo4j.Tests.NodeKey
             // Setup
             using (var session = driver.Session(o => o.WithDefaultAccessMode(AccessMode.Write)))
             {
-                session.WriteTransaction(tx => tx.Run($"CREATE {teConstraint}"));
+                session.ExecuteWrite(tx => tx.Run($"CREATE {teConstraint}"));
             }
 
             //Confirm Setup
@@ -58,7 +58,7 @@ namespace SchematicNeo4j.Tests.NodeKey
             // Setup
             using (var session = driver.Session(o => o.WithDefaultAccessMode(AccessMode.Write)))
             {
-                session.WriteTransaction(tx => tx.Run($"CREATE {teConstraint}"));
+                session.ExecuteWrite(tx => tx.Run($"CREATE {teConstraint}"));
             }
             //Confirm Setup
             Assert.Single(GetConstraints("NODE KEY", "TE"));
@@ -83,7 +83,7 @@ namespace SchematicNeo4j.Tests.NodeKey
             // Setup
             using (var session = driver.Session(o => o.WithDefaultAccessMode(AccessMode.Write)))
             {
-                session.WriteTransaction(tx => tx.Run($"CREATE {teConstraint}"));
+                session.ExecuteWrite(tx => tx.Run($"CREATE {teConstraint}"));
             }
             //Confirm Setup
             Assert.Single(GetConstraints("NODE KEY", "TE"));
@@ -119,21 +119,21 @@ namespace SchematicNeo4j.Tests.NodeKey
 
             using (var session = driver.Session(o => o.WithDefaultAccessMode(AccessMode.Write)))
             {
-                session.WriteTransaction(tx => tx.Run($"CREATE {listConstraints[0]}"));
+                session.ExecuteWrite(tx => tx.Run($"CREATE {listConstraints[0]}"));
             }
             Assert.True(SchematicNeo4j.Constraints.NodeKey.Exists(typeof(Tests.DomainSample.ThatThing), driver));
             // Test Get via Exists.
             Assert.False(SchematicNeo4j.Constraints.NodeKey.Exists(typeof(Tests.DomainSample.That), driver));
             using (var session = driver.Session(o => o.WithDefaultAccessMode(AccessMode.Write)))
             {
-                session.WriteTransaction(tx => tx.Run($"DROP {listConstraints[0]}"));
+                session.ExecuteWrite(tx => tx.Run($"DROP {listConstraints[0]}"));
             }
         }
         public void Dispose()
         {
             using (var session = driver.Session(o => o.WithDefaultAccessMode(AccessMode.Write)))
             {
-                    session.WriteTransaction(tx =>
+                    session.ExecuteWrite(tx =>
                     {
                         if (GetConstraints("NODE KEY", "TE", tx).Count() == 1)
                             tx.Run($"DROP {teConstraint}");
@@ -142,7 +142,7 @@ namespace SchematicNeo4j.Tests.NodeKey
             }
         }
 
-        private IResult GetConstraints(string ofType, string forLabel, ITransaction tx)
+        private IResult GetConstraints(string ofType, string forLabel, IQueryRunner tx)
         {
             return tx.Run(
                     "CALL db.constraints() yield description WHERE description contains (':'+$typeLabel+' ') AND description contains $constraintType RETURN description",
@@ -154,7 +154,7 @@ namespace SchematicNeo4j.Tests.NodeKey
         {
             using (var session = driver.Session(o => o.WithDefaultAccessMode(AccessMode.Read)))
             {
-                return session.ReadTransaction(tx => GetConstraints(ofType, forLabel, tx).ToList());
+                return session.ExecuteRead(tx => GetConstraints(ofType, forLabel, tx).ToList());
             }
         }
 

--- a/SchematicNeo4j/SchematicNeo4j.Tests/NodeKey/NodeKey_MatchesExisting_Tests.cs
+++ b/SchematicNeo4j/SchematicNeo4j.Tests/NodeKey/NodeKey_MatchesExisting_Tests.cs
@@ -29,7 +29,7 @@ namespace SchematicNeo4j.Tests.NodeKey
             // Setup
             using (var session = driver.Session(o => o.WithDefaultAccessMode(AccessMode.Write)))
             {
-                session.WriteTransaction(tx => tx.Run($"CREATE {meConstraint}"));
+                session.ExecuteWrite(tx => tx.Run($"CREATE {meConstraint}"));
             }
 
             //Confirm Setup
@@ -51,7 +51,7 @@ namespace SchematicNeo4j.Tests.NodeKey
             // Setup
             using (var session = driver.Session(o => o.WithDefaultAccessMode(AccessMode.Write)))
             {
-                session.WriteTransaction(tx => tx.Run($"CREATE {meConstraint}"));
+                session.ExecuteWrite(tx => tx.Run($"CREATE {meConstraint}"));
             }
             //Confirm Setup
             Assert.Single(GetConstraints("NODE KEY", "ME"));
@@ -72,7 +72,7 @@ namespace SchematicNeo4j.Tests.NodeKey
             // Setup
             using (var session = driver.Session(o => o.WithDefaultAccessMode(AccessMode.Write)))
             {
-                session.WriteTransaction(tx => tx.Run($"CREATE {meConstraint}"));
+                session.ExecuteWrite(tx => tx.Run($"CREATE {meConstraint}"));
             }
             //Confirm Setup
             Assert.Single(GetConstraints("NODE KEY", "ME"));
@@ -107,7 +107,7 @@ namespace SchematicNeo4j.Tests.NodeKey
             // Setup
             using (var session = driver.Session(o => o.WithDefaultAccessMode(AccessMode.Write)))
             {
-                session.WriteTransaction(tx => tx.Run($"CREATE {meConstraint}"));
+                session.ExecuteWrite(tx => tx.Run($"CREATE {meConstraint}"));
             }
             //Confirm Setup
             Assert.Single(GetConstraints("NODE KEY", "ME"));
@@ -129,7 +129,7 @@ namespace SchematicNeo4j.Tests.NodeKey
             // Setup to Wrong Key
             using (var session = driver.Session(o => o.WithDefaultAccessMode(AccessMode.Write)))
             {
-                session.WriteTransaction(tx => tx.Run($"CREATE CONSTRAINT ON ( me:ME ) ASSERT (me.WrongOne) IS NODE KEY"));
+                session.ExecuteWrite(tx => tx.Run($"CREATE CONSTRAINT ON ( me:ME ) ASSERT (me.WrongOne) IS NODE KEY"));
             }
             //Confirm Setup
             Assert.Single(GetConstraints("NODE KEY", "ME"));
@@ -144,7 +144,7 @@ namespace SchematicNeo4j.Tests.NodeKey
             // Setup to Wrong Key
             using (var session = driver.Session(o => o.WithDefaultAccessMode(AccessMode.Write)))
             {
-                session.WriteTransaction(tx => tx.Run($"DROP CONSTRAINT ON ( me:ME ) ASSERT (me.WrongOne) IS NODE KEY"));
+                session.ExecuteWrite(tx => tx.Run($"DROP CONSTRAINT ON ( me:ME ) ASSERT (me.WrongOne) IS NODE KEY"));
             }
         }
 
@@ -163,7 +163,7 @@ namespace SchematicNeo4j.Tests.NodeKey
         {
             using (var session = driver.Session(o => o.WithDefaultAccessMode(AccessMode.Write)))
             {
-                session.WriteTransaction(tx =>
+                session.ExecuteWrite(tx =>
                 {
                     if (GetConstraints("NODE KEY", "ME", tx).Count() == 1)
                         try
@@ -179,7 +179,7 @@ namespace SchematicNeo4j.Tests.NodeKey
             }
         }
 
-        private IResult GetConstraints(string ofType, string forLabel, ITransaction tx)
+        private IResult GetConstraints(string ofType, string forLabel, IQueryRunner tx)
         {
             return tx.Run(
                     "CALL db.constraints() yield description WHERE description contains (':'+$typeLabel+' ') AND description contains $constraintType RETURN description",
@@ -191,7 +191,7 @@ namespace SchematicNeo4j.Tests.NodeKey
         {
             using (var session = driver.Session(o => o.WithDefaultAccessMode(AccessMode.Read)))
             {
-                return session.ReadTransaction(tx => GetConstraints(ofType, forLabel, tx).ToList());
+                return session.ExecuteRead(tx => GetConstraints(ofType, forLabel, tx).ToList());
             }
         }
 

--- a/SchematicNeo4j/SchematicNeo4j.Tests/NodeKey/NodeKey_MatchesExisting_Tests.cs
+++ b/SchematicNeo4j/SchematicNeo4j.Tests/NodeKey/NodeKey_MatchesExisting_Tests.cs
@@ -12,8 +12,8 @@ namespace SchematicNeo4j.Tests.NodeKey
     public class NodeKey_MatchesExisting_Tests :IDisposable
     {
         private IDriver driver = null;
-        private string meConstraint = "CONSTRAINT ON ( me:ME ) ASSERT (me.Name) IS NODE KEY";
-
+        private string meConstraint = "CREATE CONSTRAINT `nkME` FOR (n:`ME`) REQUIRE (n.`Name`) IS NODE KEY OPTIONS {indexConfig: {}, indexProvider: 'range-1.0'}";
+        private ConstraintRecord meConstraintRecord = new() { name = "nkME" };
         public NodeKey_MatchesExisting_Tests()
         {
             driver = GraphDatabase.Driver("bolt://localhost:7687", AuthTokens.Basic("neo4j", "SchematicNeo4j-Test!"));
@@ -29,7 +29,7 @@ namespace SchematicNeo4j.Tests.NodeKey
             // Setup
             using (var session = driver.Session(o => o.WithDefaultAccessMode(AccessMode.Write)))
             {
-                session.ExecuteWrite(tx => tx.Run($"CREATE {meConstraint}"));
+                session.ExecuteWrite(tx => tx.Run($"{meConstraint}"));
             }
 
             //Confirm Setup
@@ -51,7 +51,7 @@ namespace SchematicNeo4j.Tests.NodeKey
             // Setup
             using (var session = driver.Session(o => o.WithDefaultAccessMode(AccessMode.Write)))
             {
-                session.ExecuteWrite(tx => tx.Run($"CREATE {meConstraint}"));
+                session.ExecuteWrite(tx => tx.Run($"{meConstraint}"));
             }
             //Confirm Setup
             Assert.Single(GetConstraints("NODE KEY", "ME"));
@@ -72,7 +72,7 @@ namespace SchematicNeo4j.Tests.NodeKey
             // Setup
             using (var session = driver.Session(o => o.WithDefaultAccessMode(AccessMode.Write)))
             {
-                session.ExecuteWrite(tx => tx.Run($"CREATE {meConstraint}"));
+                session.ExecuteWrite(tx => tx.Run($"{meConstraint}"));
             }
             //Confirm Setup
             Assert.Single(GetConstraints("NODE KEY", "ME"));
@@ -107,7 +107,7 @@ namespace SchematicNeo4j.Tests.NodeKey
             // Setup
             using (var session = driver.Session(o => o.WithDefaultAccessMode(AccessMode.Write)))
             {
-                session.ExecuteWrite(tx => tx.Run($"CREATE {meConstraint}"));
+                session.ExecuteWrite(tx => tx.Run($"{meConstraint}"));
             }
             //Confirm Setup
             Assert.Single(GetConstraints("NODE KEY", "ME"));
@@ -129,7 +129,7 @@ namespace SchematicNeo4j.Tests.NodeKey
             // Setup to Wrong Key
             using (var session = driver.Session(o => o.WithDefaultAccessMode(AccessMode.Write)))
             {
-                session.ExecuteWrite(tx => tx.Run($"CREATE CONSTRAINT ON ( me:ME ) ASSERT (me.WrongOne) IS NODE KEY"));
+                session.ExecuteWrite(tx => tx.Run($"CREATE CONSTRAINT nkMEWrong FOR (n:ME) REQUIRE (n.WrongOne) IS NODE KEY"));
             }
             //Confirm Setup
             Assert.Single(GetConstraints("NODE KEY", "ME"));
@@ -144,7 +144,7 @@ namespace SchematicNeo4j.Tests.NodeKey
             // Setup to Wrong Key
             using (var session = driver.Session(o => o.WithDefaultAccessMode(AccessMode.Write)))
             {
-                session.ExecuteWrite(tx => tx.Run($"DROP CONSTRAINT ON ( me:ME ) ASSERT (me.WrongOne) IS NODE KEY"));
+                session.ExecuteWrite(tx => tx.Run($"DROP CONSTRAINT nkMEWrong"));
             }
         }
 
@@ -168,7 +168,7 @@ namespace SchematicNeo4j.Tests.NodeKey
                     if (GetConstraints("NODE KEY", "ME", tx).Count() == 1)
                         try
                         {
-                            tx.Run($"DROP {meConstraint}");
+                            tx.Run($"DROP CONSTRAINT {meConstraintRecord.name}");
                         }
                         catch (Exception)
                         {
@@ -182,7 +182,7 @@ namespace SchematicNeo4j.Tests.NodeKey
         private IResult GetConstraints(string ofType, string forLabel, IQueryRunner tx)
         {
             return tx.Run(
-                    "CALL db.constraints() yield description WHERE description contains (':'+$typeLabel+' ') AND description contains $constraintType RETURN description",
+                    "SHOW CONSTRAINTS YIELD createStatement WHERE createStatement contains (':`'+$typeLabel+'`') AND createStatement contains $constraintType RETURN createStatement",
                     new { typeLabel = forLabel, constraintType = ofType }
                     );
         }

--- a/SchematicNeo4j/SchematicNeo4j.Tests/Schema_Clear_Tests.cs
+++ b/SchematicNeo4j/SchematicNeo4j.Tests/Schema_Clear_Tests.cs
@@ -174,9 +174,9 @@ namespace SchematicNeo4j.Tests
             using (var session = driver.Session(o => o.WithDefaultAccessMode(AccessMode.Write)))
             {
                 if (GetConstraints("NODE KEY", "Car").Count() == 1)
-                    session.WriteTransaction(tx => tx.Run($"DROP {carConstraint}"));
+                    session.ExecuteWrite(tx => tx.Run($"DROP {carConstraint}"));
                 if (GetConstraints("NODE KEY", "Person").Count() == 1)
-                    session.WriteTransaction(tx => tx.Run($"DROP {personConstraint}"));
+                    session.ExecuteWrite(tx => tx.Run($"DROP {personConstraint}"));
             }
         }
 
@@ -184,7 +184,7 @@ namespace SchematicNeo4j.Tests
         {
             using (var session = driver.Session(o => o.WithDefaultAccessMode(AccessMode.Read)))
             {
-                return session.ReadTransaction(tx => tx.Run(
+                return session.ExecuteRead(tx => tx.Run(
                     "CALL db.constraints() yield description WHERE description contains (':'+$typeLabel+' ') AND description contains $constraintType RETURN description",
                     new { typeLabel = forLabel, constraintType = ofType }
                     ).ToList());

--- a/SchematicNeo4j/SchematicNeo4j.Tests/Schema_Initialize_Tests.cs
+++ b/SchematicNeo4j/SchematicNeo4j.Tests/Schema_Initialize_Tests.cs
@@ -139,9 +139,9 @@ namespace SchematicNeo4j.Tests
             using (var session = driver.Session(o => o.WithDefaultAccessMode(AccessMode.Write)))
             {
                 if (GetConstraints("NODE KEY","Car").Count() == 1)
-                    session.WriteTransaction(tx => tx.Run($"DROP {carConstraint}"));
+                    session.ExecuteWrite(tx => tx.Run($"DROP {carConstraint}"));
                 if (GetConstraints("NODE KEY", "Person").Count() == 1)
-                    session.WriteTransaction(tx => tx.Run($"DROP {personConstraint}"));
+                    session.ExecuteWrite(tx => tx.Run($"DROP {personConstraint}"));
             }
         }
 
@@ -149,7 +149,7 @@ namespace SchematicNeo4j.Tests
         {
             using (var session = driver.Session(o => o.WithDefaultAccessMode(AccessMode.Read)))
             {
-                return session.ReadTransaction(tx => tx.Run(
+                return session.ExecuteRead(tx => tx.Run(
                     "CALL db.constraints() yield description WHERE description contains (':'+$typeLabel+' ') AND description contains $constraintType RETURN description",
                     new { typeLabel = forLabel, constraintType = ofType }
                     ).ToList());

--- a/SchematicNeo4j/SchematicNeo4j.Tests/Schema_SubClass_Tests.cs
+++ b/SchematicNeo4j/SchematicNeo4j.Tests/Schema_SubClass_Tests.cs
@@ -45,7 +45,7 @@ namespace SchematicNeo4j.Tests
             using (var session = driver.Session(o => o.WithDefaultAccessMode(AccessMode.Write)))
             {
                 if (GetConstraints("NODE KEY", "Car").Count() == 1)
-                    session.WriteTransaction(tx => tx.Run($"DROP {carConstraint}"));
+                    session.ExecuteWrite(tx => tx.Run($"DROP {carConstraint}"));
             }
         }
 
@@ -53,7 +53,7 @@ namespace SchematicNeo4j.Tests
         {
             using (var session = driver.Session(o => o.WithDefaultAccessMode(AccessMode.Read)))
             {
-                return session.ReadTransaction(tx => tx.Run(
+                return session.ExecuteRead(tx => tx.Run(
                     "CALL db.constraints() yield description WHERE description contains (':'+$typeLabel+' ') AND description contains $constraintType RETURN description",
                     new { typeLabel = forLabel, constraintType = ofType }
                     ).ToList()

--- a/SchematicNeo4j/SchematicNeo4j.Tests/SchematicNeo4j.Tests.csproj
+++ b/SchematicNeo4j/SchematicNeo4j.Tests/SchematicNeo4j.Tests.csproj
@@ -5,9 +5,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="xunit" Version="2.6.6" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.7.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/SchematicNeo4j/SchematicNeo4j.Tests/SchematicNeo4j.Tests.csproj
+++ b/SchematicNeo4j/SchematicNeo4j.Tests/SchematicNeo4j.Tests.csproj
@@ -5,9 +5,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.6.6" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/SchematicNeo4j/SchematicNeo4j.sln
+++ b/SchematicNeo4j/SchematicNeo4j.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.28803.452
+# Visual Studio Version 17
+VisualStudioVersion = 17.9.34414.90
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SchematicNeo4j.Attributes", "SchematicNeo4j.Attributes\SchematicNeo4j.Attributes.csproj", "{AD763B8E-29B2-4406-B667-CF67D1ADABC5}"
 EndProject
@@ -28,11 +28,9 @@ Global
 		{62158FAC-E870-4098-867D-6D3016D7B8E2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{62158FAC-E870-4098-867D-6D3016D7B8E2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{62158FAC-E870-4098-867D-6D3016D7B8E2}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{62158FAC-E870-4098-867D-6D3016D7B8E2}.Release|Any CPU.Build.0 = Release|Any CPU
 		{3011197B-F98B-4538-A009-3271300DB460}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{3011197B-F98B-4538-A009-3271300DB460}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3011197B-F98B-4538-A009-3271300DB460}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{3011197B-F98B-4538-A009-3271300DB460}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/SchematicNeo4j/SchematicNeo4j/ConstraintRecord.cs
+++ b/SchematicNeo4j/SchematicNeo4j/ConstraintRecord.cs
@@ -1,0 +1,35 @@
+﻿using Neo4j.Driver;
+using Neo4j.Driver.Preview.Mapping;
+
+namespace SchematicNeo4j
+{
+    public class ConstraintRecord
+    {
+        public string name;
+        public string type;
+        public string entityType;
+        public string[] labelsOrTypes;
+        public string[] properties;
+        public string ownedIndex;
+        public object options;
+        public string createStatement;
+
+        public static ConstraintRecord From(IRecord constraintRecord)
+        {
+
+
+            return new ConstraintRecord()
+            {
+                name = constraintRecord.GetValue<string>("name"),
+                type = constraintRecord.GetValue<string>("type"),
+                entityType = constraintRecord.GetValue<string>("entityType"),
+                labelsOrTypes = constraintRecord.GetValue<string[]>("labelsOrTypes"),
+                properties = constraintRecord.GetValue<string[]>("properties"),
+                ownedIndex = constraintRecord.GetValue<string>("ownedIndex"),
+                options = constraintRecord.GetValue<object>("options"),
+                createStatement = constraintRecord.GetValue<string>("createStatement")
+
+            };
+        }
+    }
+}

--- a/SchematicNeo4j/SchematicNeo4j/ConstraintRecord.cs
+++ b/SchematicNeo4j/SchematicNeo4j/ConstraintRecord.cs
@@ -1,5 +1,7 @@
 ﻿using Neo4j.Driver;
 using Neo4j.Driver.Preview.Mapping;
+using System;
+using System.Linq;
 
 namespace SchematicNeo4j
 {
@@ -30,6 +32,25 @@ namespace SchematicNeo4j
                 createStatement = constraintRecord.GetValue<string>("createStatement")
 
             };
+        }
+
+        public static ConstraintRecord GetNodeKeyFrom(Type domainModel)
+        {
+            var cr = new ConstraintRecord()
+            {
+                name = domainModel.NodeKeyName(),
+                type = "NODE_KEY",
+                entityType = "NODE",
+                // TODO: NODE KEY is for a single label, that's how it's been. Not going to change it for this release.
+                labelsOrTypes = new string[] { domainModel.Label().Split(':')[0] },
+                properties = domainModel.NodeKey().ToArray(),
+                ownedIndex = null,
+                options = null
+            };
+            cr.createStatement = cr.properties.Length == 0 ? String.Empty :
+                $"CREATE CONSTRAINT `{cr.name}` FOR (n:`{cr.labelsOrTypes[0]}`) REQUIRE ({String.Join(", ", cr.properties.Select(nk => $"n.`{nk}`"))}) IS NODE KEY";
+
+            return cr;
         }
     }
 }

--- a/SchematicNeo4j/SchematicNeo4j/Extensions/IndexExtensions.cs
+++ b/SchematicNeo4j/SchematicNeo4j/Extensions/IndexExtensions.cs
@@ -68,7 +68,7 @@ namespace SchematicNeo4j
         /// </remarks>
         /// <param name="type"></param>
         /// <param name="tx"></param>
-        public static void CreateIndexes(this Type type, ITransaction tx)
+        public static void CreateIndexes(this Type type, IQueryRunner tx)
         {
             type.Indexes().ForEach(idx => idx.Create(tx: tx));
         }
@@ -108,7 +108,7 @@ namespace SchematicNeo4j
         /// </summary>
         /// <param name="type"></param>
         /// <param name="tx"></param>
-        public static void DropIndexes(this Type type, ITransaction tx)
+        public static void DropIndexes(this Type type, IQueryRunner tx)
         {
             type.Indexes().ForEach(idx => idx.Drop(tx: tx));
         }

--- a/SchematicNeo4j/SchematicNeo4j/Extensions/NodeExtensions.cs
+++ b/SchematicNeo4j/SchematicNeo4j/Extensions/NodeExtensions.cs
@@ -32,5 +32,24 @@ namespace SchematicNeo4j
                 type.Name;
 
         }
+
+        public static string NodeKeyName(this Type type)
+        {
+            // Check NodeKey value in the Node Attribute.
+            NodeAttribute attr = (NodeAttribute)type.GetCustomAttribute(typeof(NodeAttribute), false);
+
+            // if the NodeKey is property is set on the attribute, then use it.
+            if (!string.IsNullOrWhiteSpace(attr?.NodeKey))
+                return attr.NodeKey;
+
+            // else use `nkPrimaryLabel`
+            var primaryLabel = (!(attr is null) && !String.IsNullOrEmpty(attr.Label)) ?
+                attr.Label.Split(':')[0] :
+            // Get the ClassName if there is no Node Attribute with a Label defined.
+                type.Name;
+            return $"nk{primaryLabel}";
+
+        }
+
     }
 }

--- a/SchematicNeo4j/SchematicNeo4j/Index.cs
+++ b/SchematicNeo4j/SchematicNeo4j/Index.cs
@@ -104,7 +104,7 @@ namespace SchematicNeo4j
         /// <param name="session"></param>
         public void Create(ISession session) 
         {
-            session.WriteTransaction(tx => { this.Create(tx); return true; });
+            session.ExecuteWrite(tx => { this.Create(tx); return true; });
         }
 
         /// <summary>
@@ -114,7 +114,7 @@ namespace SchematicNeo4j
         ///  pre neo4j version 4.0, the Index.Name is not able to be stored.
         /// </remarks>
         /// <param name="tx"></param>
-        public void Create(ITransaction tx)
+        public void Create(IQueryRunner tx)
         {
             // neo4j v4 will add name to index.
             // doesn't need to check existing because it won't duplicate.
@@ -152,7 +152,7 @@ namespace SchematicNeo4j
         /// <param name="session"></param>
         public void Drop(ISession session)
         {
-            session.WriteTransaction(tx => { this.Drop(tx); return true; });
+            session.ExecuteWrite(tx => { this.Drop(tx); return true; });
         }
 
         /// <summary>
@@ -162,7 +162,7 @@ namespace SchematicNeo4j
         ///  pre neo4j version 4.0, the Index.Name is not able to be used to match.
         /// </remarks>
         /// <param name="tx"></param>
-        public void Drop(ITransaction tx)
+        public void Drop(IQueryRunner tx)
         {
             // neo4j v4 will add name to index.
             // check existence to avoid error.
@@ -205,7 +205,7 @@ namespace SchematicNeo4j
         /// <returns></returns>
         public bool Exists(ISession session)
         {
-            return session.ReadTransaction(tx => this.Exists(tx));
+            return session.ExecuteRead(tx => this.Exists(tx));
         }
 
         /// <summary>
@@ -216,7 +216,7 @@ namespace SchematicNeo4j
         /// </remarks>
         /// <param name="tx"></param>
         /// <returns></returns>
-        public bool Exists(ITransaction tx)
+        public bool Exists(IQueryRunner tx)
         {
             var record = tx.Run(
                 "CALL db.indexes() yield indexName, tokenNames, properties, type WITH indexName as Name, tokenNames[0] as label, properties, type WHERE type = 'node_label_property' AND label = $label AND properties = $props RETURN (count(*) = 1)",

--- a/SchematicNeo4j/SchematicNeo4j/NodeKey.cs
+++ b/SchematicNeo4j/SchematicNeo4j/NodeKey.cs
@@ -99,7 +99,7 @@ namespace SchematicNeo4j.Constraints
         }
 
         /// <summary>
-        /// Determins if the domain type Node Key is the same as the Node Key in the graph.
+        /// Determines if the domain type Node Key is the same as the Node Key in the graph.
         /// </summary>
         /// <param name="type"></param>
         /// <param name="driver"></param>

--- a/SchematicNeo4j/SchematicNeo4j/NodeKey.cs
+++ b/SchematicNeo4j/SchematicNeo4j/NodeKey.cs
@@ -196,12 +196,13 @@ namespace SchematicNeo4j.Constraints
 
         private static string Get(this Type type, IQueryRunner tx)
         {
-            var record = tx.Run("SHOW CONSTRAINTS YIELD createStatement WHERE createStatement contains (':'+$typeName+' ') AND createStatement contains $constraintType RETURN createStatement", new { typeName = type.Label(), constraintType = "NODE KEY" }).FirstOrDefault();
+            var record = tx.Run("SHOW CONSTRAINTS YIELD createStatement WHERE createStatement contains (':`'+$typeName+'`') AND createStatement contains $constraintType RETURN createStatement", new { typeName = type.Label(), constraintType = "NODE KEY" }).FirstOrDefault();
             if (record is null)
                 return String.Empty;
-            else if (!record[0].As<string>().Contains(") ASSERT ("))
-                // Older versions of Neo4j a single parameter key would not have the () around it on return. But they're needed for CREATE/DROP.
-                return record[0].As<string>().Replace(") ASSERT ", ") ASSERT ( ").Replace(" IS NODE KEY", " ) IS NODE KEY");
+            // TODO: for this to handle v3 syntax, we need to add this back in.
+            //else if (!record[0].As<string>().Contains(") ASSERT ("))
+            //    // Older versions of Neo4j a single parameter key would not have the () around it on return. But they're needed for CREATE/DROP.
+            //    return record[0].As<string>().Replace(") ASSERT ", ") ASSERT ( ").Replace(" IS NODE KEY", " ) IS NODE KEY");
             else
                 return record[0].As<string>();
         }

--- a/SchematicNeo4j/SchematicNeo4j/NodeKey.cs
+++ b/SchematicNeo4j/SchematicNeo4j/NodeKey.cs
@@ -116,7 +116,7 @@ namespace SchematicNeo4j.Constraints
         }
         
         /// <summary>
-        /// Determins if the domain type Node Key is the same as the Node Key in the graph.
+        /// Determines if the domain type Node Key is the same as the Node Key in the graph.
         /// </summary>
         /// <param name="type"></param>
         /// <param name="session"></param>
@@ -175,12 +175,7 @@ namespace SchematicNeo4j.Constraints
 
         private static void Drop(this Type type, ITransaction tx)
         {
-            // TODO: For calls from SetConstraint, we're calling Exists twice. Need to refactor.
-            if (type.Exists(tx))
-            {
-                var constraint = type.NodeKeyConstraintString();
-                if (!String.IsNullOrEmpty(constraint))
-                    tx.Run($"DROP {constraint}");
+            tx.Run($"DROP CONSTRAINT {type.NodeKeyName()} IF EXISTS");
             }
 
         }

--- a/SchematicNeo4j/SchematicNeo4j/Schema.cs
+++ b/SchematicNeo4j/SchematicNeo4j/Schema.cs
@@ -28,7 +28,7 @@ namespace SchematicNeo4j
 
             using (var session = driver.Session(sessionConfigOptions))
             {
-                return session.WriteTransaction(tx =>
+                return session.ExecuteWrite(tx =>
                 {
                     foreach (Type type in domainTypes)
                     {
@@ -52,7 +52,7 @@ namespace SchematicNeo4j
 
             using (var session = driver.Session(sessionConfigOptions))
             {
-                return session.WriteTransaction(tx => {
+                return session.ExecuteWrite(tx => {
                     type.SetNodeKey(tx);
                     type.CreateIndexes(tx);
                     return true;
@@ -79,7 +79,7 @@ namespace SchematicNeo4j
 
             using (var session = driver.Session(sessionConfigOptions))
             {
-                return session.WriteTransaction(tx => {
+                return session.ExecuteWrite(tx => {
                     foreach (Type type in domainTypes)
                     {
                         type.RemoveNodeKey(tx);
@@ -102,7 +102,7 @@ namespace SchematicNeo4j
 
             using (var session = driver.Session(sessionConfigOptions))
             {
-                return session.WriteTransaction(tx => {
+                return session.ExecuteWrite(tx => {
                     type.RemoveNodeKey(tx);
                     type.DropIndexes(tx);
                     return true;

--- a/SchematicNeo4j/SchematicNeo4j/SchematicNeo4j.csproj
+++ b/SchematicNeo4j/SchematicNeo4j/SchematicNeo4j.csproj
@@ -15,7 +15,8 @@ Helpful in quickly and consistently managing graph schema for your domain model.
     <PackageLicenseExpression></PackageLicenseExpression>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageReleaseNotes>
-Version 2.0.0: Updated to work with neo4j graph version 4.4 -&gt; 5.x and neo4j-dotnet-driver 5.x and target net8.0LTS
+Version 2.0.0: Updated to work with neo4j graph version 4.4 -&gt; 5.x and neo4j-dotnet-driver 5.17
+       - Added target for net8.0LTS and netframework 4.8.1
        - Added Relationship Entity for Indexes and Constraints
       
 Version 1.3.0: Updated to use neo4j-dotnet-driver 4.x with graph version 3.5.x (3.5.17 and 3.5.21 were tested).

--- a/SchematicNeo4j/SchematicNeo4j/SchematicNeo4j.csproj
+++ b/SchematicNeo4j/SchematicNeo4j/SchematicNeo4j.csproj
@@ -41,8 +41,8 @@ Methods:
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Neo4j.Driver" Version="5.8.0" />
-    <PackageReference Include="Neo4j.Driver.Simple" Version="5.8.0" />
+    <PackageReference Include="Neo4j.Driver" Version="5.16.0" />
+    <PackageReference Include="Neo4j.Driver.Simple" Version="5.16.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SchematicNeo4j/SchematicNeo4j/SchematicNeo4j.csproj
+++ b/SchematicNeo4j/SchematicNeo4j/SchematicNeo4j.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>net8.0;netstandard2.0;net481</TargetFrameworks>
     <PackageId>SchematicNeo4j</PackageId>
-    <Version>1.3.0</Version>
+    <Version>2.0.0</Version>
     <Authors>Mike French; mdfrenchman</Authors>
     <Company></Company>
     <Owner>mdfrenchman</Owner>
@@ -14,7 +14,11 @@ Helpful in quickly and consistently managing graph schema for your domain model.
     <PackageTags>SchematicNeo4j neo4j code-first schema nosql dotnet</PackageTags>
     <PackageLicenseExpression></PackageLicenseExpression>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    <PackageReleaseNotes>Version 1.3.0: Updated to use neo4j-dotnet-driver 4.x with graph version 3.5.x (3.5.17 and 3.5.21 were tested).
+    <PackageReleaseNotes>
+Version 2.0.0: Updated to work with neo4j graph version 4.4 -&gt; 5.x and neo4j-dotnet-driver 5.x and target net8.0LTS
+       - Added Relationship Entity for Indexes and Constraints
+      
+Version 1.3.0: Updated to use neo4j-dotnet-driver 4.x with graph version 3.5.x (3.5.17 and 3.5.21 were tested).
 Version 1.0.0: Added Index management with Index object that maps to the IndexAttribute.  
        - Index matching is done by Label and Properties for neo4j version 3.x
        - Create/Drop of indexes added to Schema.Initialize and Schema.Clear
@@ -41,8 +45,8 @@ Methods:
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Neo4j.Driver" Version="5.16.0" />
-    <PackageReference Include="Neo4j.Driver.Simple" Version="5.16.0" />
+    <PackageReference Include="Neo4j.Driver" Version="5.17.0" />
+    <PackageReference Include="Neo4j.Driver.Simple" Version="5.17.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- resolves #10  ; node key tests pass for v5 create, drop, exists, and exists match. Constraint is now dropped by name. node key name can be specified in the class attribute: `[Node(Label = "Car", NodeKey = "carMakeModelYear")]`
- resolves #16  ; uses IQueryRunner in preparation for v6 driver.